### PR TITLE
perf: use nix::sys::utsname::uname for less syscalls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.3"
 edition = "2021"
 
 [dependencies]
-nix = {version = "0.29", features = ["fs", "hostname"]}
+nix = { version = "0.29", features = ["fs", "hostname", "feature"] }
 color-eyre = { version = "0.6", default-features = false }
 
 [profile.dev]

--- a/src/release.rs
+++ b/src/release.rs
@@ -1,30 +1,15 @@
 use color_eyre::Result;
-use std::fs::{self, read_to_string};
+use std::fs::read_to_string;
 use std::io;
 
-// Try to detect OS type as accurately as possible and without depending on uname.
-// /etc/os-release should generally imply Linux, and /etc/bsd-release would imply BSD system.
-fn detect_os() -> Result<&'static str, io::Error> {
-    if fs::metadata("/etc/os-release").is_ok() || fs::metadata("/usr/lib/os-release").is_ok() {
-        Ok("Linux")
-    } else if fs::metadata("/etc/rc.conf").is_ok() || fs::metadata("/etc/bsd-release").is_ok() {
-        Ok("BSD")
-    } else {
-        Ok("Unknown")
-    }
-}
-
-pub fn get_system_info() -> Result<String, io::Error> {
-    let system = detect_os()?;
-
-    let kernel_release = read_to_string("/proc/sys/kernel/osrelease")?;
-    let kernel_release = kernel_release.trim();
-
-    let architecture = read_to_string("/proc/sys/kernel/arch")?;
-    let architecture = architecture.trim();
-
-    let result = format!("{system} {kernel_release} ({architecture})");
-    Ok(result)
+pub fn get_system_info() -> nix::Result<String> {
+    let utsname = nix::sys::utsname::uname()?;
+    Ok(format!(
+        "{} {} ({})",
+        utsname.sysname().to_str().unwrap_or("Unknown"),
+        utsname.release().to_str().unwrap_or("Unknown"),
+        utsname.machine().to_str().unwrap_or("Unknown")
+    ))
 }
 
 pub fn get_os_pretty_name() -> Result<String, io::Error> {


### PR DESCRIPTION
Instead of reading multiple files to get the `sysname`, `release`, and `machine` name, use the `nix::sys::utsname::uname` function which sends a single uname syscall instead. This increases performance and portability.

From my observations, there are ~10 less syscalls.