### PR TITLE
removing excess frequency value

### DIFF
--- a/crates/lib/src/cpu.rs
+++ b/crates/lib/src/cpu.rs
@@ -340,7 +340,12 @@ fn extract_field<'a>(data: &'a [u8], key: &[u8]) -> Option<&'a str> {
         while p < line.len() && line[p] == b' ' {
           p += 1;
         }
-        return core::str::from_utf8(&line[p..]).ok();
+        //remove the frequency in model name as its resolved later
+        let mut hz = p+1;
+        while hz < line.len() && line[hz] != b'@' {
+            hz += 1;
+        }
+        return core::str::from_utf8(&line[p..hz-1]).ok();
       }
     }
 

--- a/crates/lib/src/cpu.rs
+++ b/crates/lib/src/cpu.rs
@@ -255,6 +255,10 @@ fn get_model_name() -> Option<String> {
   let base = extract_name(data)?;
   let mut name = base;
   if let Some(mhz) = get_cpu_freq_mhz() {
+    if let Some(at) = name.find(" @ ") {
+      name.truncate(at);
+    }
+    
     name.push_str(" @ ");
     // Round to nearest 0.01 GHz, then split so carries (e.g. 1999 MHz)
     // roll into the integer part instead of overflowing the fraction.
@@ -340,12 +344,7 @@ fn extract_field<'a>(data: &'a [u8], key: &[u8]) -> Option<&'a str> {
         while p < line.len() && line[p] == b' ' {
           p += 1;
         }
-        //remove the frequency in model name as its resolved later
-        let mut hz = p+1;
-        while hz < line.len() && line[hz] != b'@' {
-            hz += 1;
-        }
-        return core::str::from_utf8(&line[p..hz-1]).ok();
+        return core::str::from_utf8(&line[p..]).ok();
       }
     }
 

--- a/crates/lib/src/cpu.rs
+++ b/crates/lib/src/cpu.rs
@@ -319,17 +319,23 @@ fn write_model_name(w: &mut StackWriter) {
   };
   let data = &buf[..n];
 
-  let found = if let Some(name) = extract_name(data) {
-    w.push_str(name);
-    true
-  } else {
-    write_dt_compatible(w)
-  };
-  if !found {
+  let name = extract_name(data);
+  if name.is_none() && !write_dt_compatible(w) {
     return;
   }
 
-  if let Some(mhz) = get_cpu_freq_mhz() {
+  let mhz = get_cpu_freq_mhz();
+  if let Some(name) = name {
+    // x86 `model name` already ends in `@ <clock>GHz`, which hides the
+    // ` CPU` that trim() would otherwise strip, so re-trim after cutting.
+    let name = match (mhz, name.find(" @ ")) {
+      (Some(_), Some(at)) => trim(&name[..at]),
+      _ => name,
+    };
+    w.push_str(name);
+  }
+
+  if let Some(mhz) = mhz {
     w.push_str(" @ ");
     // Round to nearest 0.01 GHz, then split so carries (e.g. 1999 MHz)
     // roll into the integer part instead of overflowing the fraction.


### PR DESCRIPTION
After updating microfetch to the version 1.1.0, I got a problem with the frequency of the cpu printed. More precisely, the value is appearing twice as seen in the following image.

<img width="1559" height="424" alt="Screenshot" src="https://github.com/user-attachments/assets/f0a853e4-e7c4-416f-a674-2d9f34ddf148" />

The problem appears because now microfetch is looking for the frequency by itself but the frequency is present directly in the name of the cpu model.

To resolve the problem and keep the lookup by microfetch, the code is now looking for a part where "@" can exist and then trim it with the frequency value from the name. 